### PR TITLE
Make Network Manager the default backend for all

### DIFF
--- a/desktopify
+++ b/desktopify
@@ -22,3 +22,10 @@ HARDWARE_PACKAGES="pi-bluetooth"
 
 apt install "${DESKTOP_PACKAGES}^"
 apt install "${HARDWARE_PACKAGES}"
+
+mv /etc/netplan/50-cloud-init.yaml /etc/netplan/50-cloud-init.yaml.bak
+cat <<'EOF' > /etc/netplan/10-networkmanager-all.yaml
+network:
+  version: 2
+  renderer: NetworkManager
+EOF


### PR DESCRIPTION
I've added in the config to make networkmanager the default renderer for netplan. As part of this, I am also backing up the original netplan config which is generated by cloud-init on the original install. I've tested and it appears to work for me!