### PR TITLE
Github Actions: minor: remove duplicate file type checking in find

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: |
-        find $GITHUB_WORKSPACE -type f -and \( -name "*.sh" -or -type f -name "desktopify" \) | xargs shellcheck
+        find $GITHUB_WORKSPACE -type f -and \( -name "*.sh" -or -name "desktopify" \) | xargs shellcheck


### PR DESCRIPTION
Remove duplicated `-type f` in find command for shellcheck.

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>