### PR TITLE
Install GPIO tools

### DIFF
--- a/desktopify
+++ b/desktopify
@@ -212,7 +212,7 @@ if [ "${CODENAME}" != "focal" ]; then
 fi
 
 # Do the installation
-HARDWARE_PACKAGES="pi-bluetooth"
+HARDWARE_PACKAGES="pi-bluetooth libgpiod-dev python3-libgpiod python3-gpiozero"
 echo "[+] Will now install ${DESKTOP_PACKAGES} and ${HARDWARE_PACKAGES}"
 
 #Check if system already has a desktop installed


### PR DESCRIPTION
- Installing the official gpiozero library should provide the tools found on the Raspbian OS, including the `pinout` command.

- We also install the official kernel interface library enabling people to use that alternative interface from C/C++ and Python.

See here for details on GPIO on the Pi: https://www.raspberrypi.org/documentation/usage/gpio/