### PR TITLE
Move "install GPIO tools" task from TODO to Done

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,12 @@ wizard on the next boot.
 ## TODO
 
 - [ ] Create a snap
-- [ ] Install gpio tools
 - [ ] Emoji status
 - [ ] Enable boot splash
 
 ## DONE
 
+- [x] Install GPIO utilities and libraries
 - [x] Enable Bluetooth
 - [x] Make sure it's Ubuntu on a Pi
 - [x] Make Network Manager the default backend


### PR DESCRIPTION
This PR moves the GPIO tools item in the TODO list in README.md to the DONE list

I forgot to make this change in my original PR where I actually added the GPIO tools