### PR TITLE
Remove use of apt

### DIFF
--- a/desktopify
+++ b/desktopify
@@ -230,7 +230,7 @@ fi
 HARDWARE_PACKAGES=(libgles1 libopengl0 libxvmc1 pi-bluetooth libgpiod-dev python3-libgpiod python3-gpiozero)
 
 #Check if system already has a desktop installed
-if [ "$(apt list --installed ${DESKTOP_PACKAGES} 2>/dev/null | grep installed)" ] && [ "${FORCE}" -eq 0 ]; then
+if [[ ${FORCE} -eq 0 ]] && { dpkg -l "${DESKTOP_PACKAGES}" &>/dev/null; }; then
   echo "[*] WARNING: ${DESKTOP_PACKAGES} already installed. To force install use the --force option."
 else
   echo "[+] Will now install ${DESKTOP_PACKAGES}"

--- a/desktopify
+++ b/desktopify
@@ -72,7 +72,7 @@ EOM
 
 function enable_oem() {
   if [ "${ENABLE_OEM}" -eq 1 ] && [ "${DESKTOP_ENVIRONMENT}" != "lubuntu" ]; then
-    apt -y install whois
+    apt-get -y install whois
     local DATE=""
     DATE=$(date +%m%H%M%S)
     local PASSWD=""
@@ -234,7 +234,7 @@ if [ "$(apt list --installed ${DESKTOP_PACKAGES} 2>/dev/null | grep installed)" 
   echo "[*] WARNING: ${DESKTOP_PACKAGES} already installed. To force install use the --force option."
 else
   echo "[+] Will now install ${DESKTOP_PACKAGES}"
-  apt install -y ${DESKTOP_PACKAGES}^
+  apt-get -y install ${DESKTOP_PACKAGES}^
 fi
 
 for CLASSIC_SNAP in "${CLASSIC_SNAPS[@]}"; do
@@ -246,7 +246,7 @@ for CONFINED_SNAP in "${CONFINED_SNAPS[@]}"; do
 done
 
 echo "[+] Will now install ${HARDWARE_PACKAGES[*]}"
-apt install -y "${HARDWARE_PACKAGES[@]}"
+apt-get -y install "${HARDWARE_PACKAGES[@]}"
 
 configure_network
 apply_tweaks


### PR DESCRIPTION
Use of `apt` in scripts is discouraged since it is meant as a user facing tool and is subject to interface change. `apt-get` and `apt` are currently used at different points in desktopify. This PR changes all instances of `apt install` to `apt-get install`.

In addition the check for already installed packages is changed to use `dpkg` which besides eliminating the discouraged `apt` also provides the advantage of returning the status of whether the packages are installed via the exit code so grepping output is not needed. I also reversed the order of the checks so `dpkg` is only run if the force option is not set.