### PR TITLE
Add video fix for SDDM to work properly.

### DIFF
--- a/desktopify
+++ b/desktopify
@@ -43,6 +43,7 @@ EOM
 #
 disable_overscan=1
 dtoverlay=vc4-fkms-v3d
+start_x=1
 hdmi_drive=2
 EOM
 


### PR DESCRIPTION
This change allows SDDM to display properly and should close #19 and #63 . I have also tested a Mate install and no regression was noted. The [documentation](https://www.raspberrypi.org/documentation/configuration/config-txt/boot.md) also indicates this should be set when using the camera module. 