### PR TITLE
Codename check: use Case instead of Ifs

### DIFF
--- a/desktopify
+++ b/desktopify
@@ -225,10 +225,15 @@ fi
 
 # Check if we're running 20.04
 CODENAME=$(lsb_release -cs)
-if [ "${CODENAME}" != "focal" ]; then
-  echo "[!] This script is only intended to run on Ubuntu 20.04."
-  exit 1
-fi
+case ${CODENAME} in
+    focal)
+        # Do nothing, as this is a supported release.
+        ;;
+    *)
+        echo "[!] This script is only intended to run on Ubuntu 20.04."
+        exit 1
+        ;;
+esac
 
 # Do the installation
 HARDWARE_PACKAGES=(libgles1 libopengl0 libxvmc1 pi-bluetooth libgpiod-dev python3-libgpiod python3-gpiozero)


### PR DESCRIPTION
Case conditionals are more expandable for multiple string matches and in the long term for future version support will greatly reduce the codename checks - it's easier to simply add a codename to the case list than to add multiple `if` checks in a way that ShellCheck will accept.  This allows easy adding of any future codename to the supported list without needing to duplicate the `if` checks for future version matches in a way that Shellcheck would complain about.